### PR TITLE
Add local testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ cover_db
 *.patch
 setup
 mess/
+.build
+cpanfile.snapshot
+local/
+.perl-version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+Contributing to Glow
+====================
+
+## Getting Started
+
+If you have carton available you should just be able to
+clone this repo, change to the directory, and run `make test`.
+
+### Installing dependencies
+
+The dependencies for this project are listed in its `cpanfile`,
+this file is usually handled by [Carton](https://metacpan.org/pod/Carton).
+
+Installing Carton can be done with any CPAN client into whichever version of perl you want to use.
+
+If you don't have permission, or just don't want to install things into your system perl, you can use [App::Plenv](https://github.com/tokuhirom/plenv) and the [perl-build](https://github.com/tokuhirom/perl-build) plugin, or [Perlbrew](https://perlbrew.pl/) to install different versions of perl.
+
+Once you have a version of perl to use for testing this, if you don't have a preference for a CPAN client, we recommend you use [cpanminus](https://metacpan.org/pod/App::cpanminus#Installing-to-system-perl).
+
+With `plenv` you are able to get cpanminus with `plenv install-cpanm`.
+
+Otherwise, quoting the cpanminus quickstart instructions:
+
+> Quickstart: Run the following command and it will install itself for you.
+> You might want to run it as a root with sudo if you want to
+> install to places like /usr/local/bin.
+>
+>   `% curl -L https://cpanmin.us | perl - App::cpanminus`
+>
+> If you don't have curl but wget, replace `curl -L` with `wget -O -`.
+
+Once you have cpanminus, you can install Carton with:
+
+    cpanm Carton
+
+With `carton` available, you can run `make test` and make sure tests pass.  If they do, you're ready to start making changes and get ready to create a Pull Request.
+
+### Using Dist::Zilla
+
+The release of this distribution is managed by [Dist::Zilla](http://dzil.org) which provides a lot of benefits for managing releases and modules at the expense of longer a learning curve.
+
+However, you probably don't need it unless you want to build a release or run author tests.
+
+In order to work with Dist::Zilla's `dzil` you will need to run `carton install` manually as the Makefile uses `--without develop` to avoid unnecessary dependencies.
+
+Once those dependencies are installed, you need to use `carton exec dzil` so it can find them.
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+# This is based on the version in Dist::Zilla::PluginBundle::Author::GSG
+# See the docmentation for that module for details.
+
+DIST_NAME   ?= $(shell perl -ne '/^\s*name\s*=\s*(\S+)/ && print $$1' dist.ini )
+MAIN_MODULE ?= $(shell perl -ne '/^\s*main_module\s*=\s*(\S+)/ && print $$1' dist.ini )
+
+CARTON            ?= $(shell which carton 2>/dev/null || echo carton )
+CPANFILE_SNAPSHOT ?= $(shell \
+  carton exec perl -MFile::Spec -e \
+	'($$_) = grep { -e } map{ "$$_/../../cpanfile.snapshot" } \
+		grep { m(/lib/perl5$$) } @INC; \
+		print File::Spec->abs2rel($$_) . "\n" if $$_' 2>/dev/null )
+
+ON_DEVELOP := $(shell $(CARTON) exec -- \
+	dzil nop >/dev/null 2>/dev/null && echo $(CARTON) || echo develop )
+
+ifeq ($(MAIN_MODULE),)
+MAIN_MODULE := lib/$(subst -,/,$(DIST_NAME)).pm
+endif
+ifeq ($(CPANFILE_SNAPSHOT),)
+CPANFILE_SNAPSHOT    := cpanfile.snapshot
+endif
+CARTON_INSTALL_FLAGS ?= --without develop
+PERL_CARTON_PERL5LIB ?= $(PERL5LIB)
+
+.PHONY : test clean realclean develop carton
+
+test : $(CPANFILE_SNAPSHOT)
+	@nice $(CARTON) exec prove -lfr t
+
+# This target requires that you add 'requires "Devel::Cover";'
+# to the cpanfile and then run "carton" to install it.
+testcoverage : $(CPANFILE_SNAPSHOT)
+	$(CARTON) exec -- cover -test -ignore . -select ^lib
+
+clean:
+	$(CARTON) exec dzil clean || true
+	rm -rf .build
+
+realclean: clean
+	rm -rf local
+
+# If dzil run can provide these items with different Plugins,
+# we could update the repo with new versions by running make update.
+#
+#update: README.md LICENSE.txt
+#	@echo Everything is up to date
+#
+#README.md: $(MAIN_MODULE) dist.ini $(ON_DEVELOP)
+#	$(CARTON) exec dzil run sh -c "pod2markdown $< > ${CURDIR}/$@"
+#
+#LICENSE.txt: dist.ini $(ON_DEVELOP)
+#	$(CARTON) exec dzil run sh -c "install -m 644 LICENSE ${CURDIR}/$@"
+
+$(CPANFILE_SNAPSHOT): $(CARTON) cpanfile
+	$(CARTON) install $(CARTON_INSTALL_FLAGS)
+
+develop: $(CPANFILE_SNAPSHOT)
+	$(CARTON) install # with develop
+
+carton:
+	@echo You must install carton: https://metacpan.org/pod/Carton >&2;
+	@false;

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,47 @@
+requires "strict";
+requires "warnings";
+
+requires "Digest";
+requires "Encode";
+requires "FileHandle";
+requires "Fcntl";
+requires "IO::File";
+requires "List::Util";
+
+requires "Moose";
+requires "Moose::Role";
+requires "MooseX::Role::Parameterized";
+requires "MooseX::Types::Path::Class";
+requires "namespace::autoclean";
+
+requires "Config::GitLike";
+
+requires "DateTime";
+requires "DateTime::TimeZone";
+
+requires "IO::Compress::Deflate";
+requires "IO::Uncompress::Inflate";
+requires "IO::String";
+
+requires "Path::Class::Dir";
+requires "Path::Class::File";
+
+on test => sub {
+	requires "File::Temp";
+	requires "Test::More";
+};
+
+on develop => sub {
+	requires "Dist::Zilla::PluginBundle::Filter";
+	requires "Dist::Zilla::PluginBundle::Git";
+
+	requires "Dist::Zilla::Plugin::AutoPrereqs";
+	requires "Dist::Zilla::Plugin::Git::NextVersion";
+	requires "Dist::Zilla::Plugin::MetaResources";
+	requires "Dist::Zilla::Plugin::NextRelease";
+	requires "Dist::Zilla::Plugin::PkgVersion";
+	requires "Dist::Zilla::Plugin::PodWeaver";
+	requires "Dist::Zilla::Plugin::Prereqs";
+	requires "Dist::Zilla::Plugin::PruneFiles";
+	requires "Dist::Zilla::Plugin::ReportVersions::Tiny";
+};


### PR DESCRIPTION
I got here from the pullrequest.club but didn't find any open issues for this project, so thought I could help other folks get started.  

This is mostly a copy of what I did [for the open source stuff at work](https://github.com/GrantStreetGroup/p5-Dist-Zilla-PluginBundle-Author-GSG), slightly modified because you don't actually use our PluginBundle.  The main feature I like is that you don't have to install the heavy Dist::Zilla dependencies to contribute.  That is not especially helpful in this case since we need to install Moose anyway, but it helps some, saving around 10M of space in my local/ dir.  It also means you can run `make test` if you have [Carton](metacpan.org/pod/Carton) available and it should install the necessary dependencies and run the tests.

I didn't look at what "gather" Plugin you're using, so it's possible the Makefile here will confuse Dist::Zilla.  However, although tests without Dist::Zilla work, trying to run `dzil test` fails in several ways for me.